### PR TITLE
`extra_html` should be empty string when `suppress_no_follow` is True.

### DIFF
--- a/twitter_text/autolink.py
+++ b/twitter_text/autolink.py
@@ -71,7 +71,7 @@ class Autolink(object):
             'list_url_base': 'http://twitter.com/',
         }
         kwargs.update(defaults)
-        extra_html = kwargs.get('suppress_no_follow', False) or self.HTML_ATTR_NO_FOLLOW
+        extra_html = '' if kwargs.get('suppress_no_follow', False) else self.HTML_ATTR_NO_FOLLOW
     
         matches = REGEXEN['auto_link_usernames_or_lists'].finditer(self.text)
         for match in matches:
@@ -117,7 +117,7 @@ class Autolink(object):
             'hashtag_url_base': 'http://twitter.com/search?q=%23',
         }
         kwargs.update(defaults)
-        extra_html = kwargs.get('suppress_no_follow', False) or self.HTML_ATTR_NO_FOLLOW
+        extra_html = '' if kwargs.get('suppress_no_follow', False) else self.HTML_ATTR_NO_FOLLOW
     
         matches = REGEXEN['auto_link_hashtags'].finditer(self.text)
         for match in matches:


### PR DESCRIPTION
When `suppress_no_follow` is True, extra_html is being set to `True`. It should actually be an empty string.
