### PR TITLE
Fix handling of default options

### DIFF
--- a/twitter_text/autolink.py
+++ b/twitter_text/autolink.py
@@ -113,7 +113,7 @@ class Autolink(object):
             return self.text
 
         # NOTE deprecate these attributes not options keys in options hash, then use html_attrs
-        options.update(DEFAULT_OPTIONS)
+        options = dict(DEFAULT_OPTIONS.items() + options.items())
         options['html_attrs'] = self._extract_html_attrs_from_options(options)
         if not options.get('suppress_no_follow', False):
             options['html_attrs']['rel'] = "nofollow"


### PR DESCRIPTION
The previous approach overwrote all the options with the ones from the `DEFAULT_OPTIONS` dictionary. Reverse this, so that the options passed in overwrite the default ones.
